### PR TITLE
Fix pid set to NaN in browserify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/objectid.js
+++ b/objectid.js
@@ -1,7 +1,7 @@
 
 var MACHINE_ID = parseInt(Math.random() * 0xFFFFFF, 10);
 var index = ObjectID.index = parseInt(Math.random() * 0xFFFFFF, 10);
-var pid = typeof process === 'undefined' ? Math.floor(Math.random() * 100000) : process.pid % 0xFFFF;
+var pid = typeof process === 'undefined' || typeof process.pid !== 'number' ? Math.floor(Math.random() * 100000) : process.pid % 0xFFFF;
 
 /**
  * Determine if an object is Buffer


### PR DESCRIPTION
 - Added a check to see if the `process.pid` exists, as browserify provides a `process` global but it does not have a `pid` property. 
 - Also added `node_modules/` to `.gitignore`

That conditional statement is a bit long now, so let me know if you want me to break it up or something.

Fixes #4 