### PR TITLE
Fix generating 26 char id

### DIFF
--- a/objectid.js
+++ b/objectid.js
@@ -1,7 +1,7 @@
 
 var MACHINE_ID = parseInt(Math.random() * 0xFFFFFF, 10);
 var index = ObjectID.index = parseInt(Math.random() * 0xFFFFFF, 10);
-var pid = typeof process === 'undefined' || typeof process.pid !== 'number' ? Math.floor(Math.random() * 100000) : process.pid % 0xFFFF;
+var pid = typeof process === 'undefined' || (typeof process.pid !== 'number' ? Math.floor(Math.random() * 100000) : process.pid) % 0xFFFF;
 
 /**
  * Determine if an object is Buffer


### PR DESCRIPTION
 - Fix pid sometimes being greater than 0xFFFF in a browser, causing generate() to return a 26-character id.

Fixes #6