### PR TITLE
fix to undefined process returning true in objectID string

### DIFF
--- a/objectid.js
+++ b/objectid.js
@@ -1,7 +1,7 @@
 
 var MACHINE_ID = parseInt(Math.random() * 0xFFFFFF, 10);
 var index = ObjectID.index = parseInt(Math.random() * 0xFFFFFF, 10);
-var pid = typeof process === 'undefined' || (typeof process.pid !== 'number' ? Math.floor(Math.random() * 100000) : process.pid) % 0xFFFF;
+var pid = (typeof process === 'undefined' || typeof process.pid !== 'number' ? Math.floor(Math.random() * 100000) : process.pid) % 0xFFFF;
 
 /**
  * Determine if an object is Buffer
@@ -178,4 +178,3 @@ function buffer(str) {
 ObjectID.prototype.inspect = function() { return "ObjectID("+this+")" };
 ObjectID.prototype.toJSON = ObjectID.prototype.toHexString;
 ObjectID.prototype.toString = ObjectID.prototype.toHexString;
-


### PR DESCRIPTION
When process is undefined, pid returns true. This causes the generate function to return an ObjectID string containing 'true'.