### PR TITLE
default export

### DIFF
--- a/objectid.d.ts
+++ b/objectid.d.ts
@@ -2,7 +2,7 @@
 // Project: bson-objectid
 // Definitions by: Marcel Ernst <https://www.marcel-ernst.de>
 
-export = ObjectID;
+export default ObjectID;
 
 declare class ObjectID {
     static createFromTime(time: number): ObjectID;

--- a/objectid.js
+++ b/objectid.js
@@ -56,6 +56,7 @@ function ObjectID(arg) {
 }
 module.exports = ObjectID;
 ObjectID.generate = generate;
+ObjectID.default = ObjectID;
 
 /**
  * Creates an ObjectID from a second based number, with the rest of the ObjectID zeroed out. Used for comparisons or sorting the ObjectID.

--- a/typing-tests/objectid-tests.ts
+++ b/typing-tests/objectid-tests.ts
@@ -1,5 +1,5 @@
 /// <reference path="../objectid.d.ts" />
-import ObjectID = require('../objectid');
+import ObjectID from '../objectid';
 
 // ----------------------------------------------------------------------------
 // setup test data
@@ -12,7 +12,7 @@ const idString:string = "TIZÙLG!íçm";
 
 // ----------------------------------------------------------------------------
 // should construct with no arguments
-let oid:ObjectID = new ObjectID();
+let oid = new ObjectID();
 
 // ----------------------------------------------------------------------------
 // should have an `id` property


### PR DESCRIPTION
Since 1.2.0 ,there is some problem type error. such as #13

In most cases , TypeScript use es6 syntax import , for example `import xx from 'oo'` , which will more common to use.