### PR TITLE
Use Math.floor instead of parseInt when generating MACHINE_ID

### DIFF
--- a/objectid.js
+++ b/objectid.js
@@ -1,5 +1,5 @@
 
-var MACHINE_ID = parseInt(Math.random() * 0xFFFFFF, 10);
+var MACHINE_ID = Math.floor(Math.random() * 0xFFFFFF);
 var index = ObjectID.index = parseInt(Math.random() * 0xFFFFFF, 10);
 var pid = (typeof process === 'undefined' || typeof process.pid !== 'number' ? Math.floor(Math.random() * 100000) : process.pid) % 0xFFFF;
 


### PR DESCRIPTION
While parseInt works, it's intended for converting strings to numbers, and the expression `Math.random() * 0xFFFFFF` will always be a number.