### PR TITLE
package.json: change typings to types

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.2.4",
   "description": "Construct ObjectIDs without the mongodb driver or bson module",
   "main": "objectid.js",
-  "typings": "./objectid.d.ts",
+  "types": "./objectid.d.ts",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
Hi!

According to new TypeScript Publishing rules this field should be called `types` instead

TS Publishing Docs: https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html

Thanks :heart: 