### PR TITLE
fix: added check for Array.isArray

### DIFF
--- a/objectid.js
+++ b/objectid.js
@@ -95,7 +95,7 @@ ObjectID.createFromHexString = function(hexString) {
  * http://mongodb.github.io/node-mongodb-native/api-bson-generated/objectid.html#objectid-isvalid
  */
 ObjectID.isValid = function(objectid) {
-  if(!objectid || (typeof objectid !== 'string' && (typeof objectid !== 'object' || typeof objectid.toString !== 'function'))) return false;
+  if(!objectid || (typeof objectid !== 'string' && (typeof objectid !== 'object' || Array.isArray(objectid) || typeof objectid.toString !== 'function'))) return false;
 
   //call .toString() to get the hex if we're
   // working with an instance of ObjectID


### PR DESCRIPTION
Without this check in place, the following uncaught exception is thrown:

```sh
✖  error     TypeError: argument must be a buffer
    at Array.toString (buffer.js:763:17)
    at Function.ObjectID.isValid (/Users/jack/Projects/forwardemail.net/node_modules/bson-objectid/objectid.js:104:50)
```

Please merge and release to npm asap!  Thank you! 👏 