### PR TITLE
Symbol.for somehow, sometimes goes missing

### DIFF
--- a/objectid.js
+++ b/objectid.js
@@ -211,7 +211,7 @@ function buffer(str) {
   return out;
 }
 
-var inspect = (Symbol && Symbol.for('nodejs.util.inspect.custom')) || 'inspect';
+var inspect = (Symbol && Symbol.for && Symbol.for('nodejs.util.inspect.custom')) || 'inspect';
 
 /**
  * Converts to a string representation of this Id.


### PR DESCRIPTION
I use bson-objectid in my app Stickies - https://github.com/carbonfive/stickies

I have noticed that from time to time the line that I changed in this PR breaks with "undefined is not a function".  What I have found out is that somehow the function `Symbol.for` is getting removed from `Symbol`.  It's only happening in Chrome on Windows, which leads me to believe there is some Windows-specific Chrome extension that is doing it.

This change just makes one more undefined check before calling `Symbol.for`.