### PR TITLE
Updated types to support calling `ObjectID()` without the `new` keyword

### DIFF
--- a/objectid.d.ts
+++ b/objectid.d.ts
@@ -1,29 +1,39 @@
-// Type definitions for bson-objectid 1.3.1
-// Project: bson-objectid
-// Definitions by: Marcel Ernst <https://www.marcel-ernst.de>
-import { Buffer } from 'buffer';
-export default ObjectID;
+import {Buffer} from 'buffer';
 
-declare class ObjectID {
-    static createFromTime(time: number): ObjectID;
-    static createFromHexString(hexString: string): ObjectID;
-    static isValid(hexString: string):boolean;
-    static isValid(ObjectID: ObjectID):boolean;
-    static generate(): string;
-    static generate(time: number): string;
-    static toString():string;
+export default ObjectID
 
-    constructor();
-    constructor(time: number);
-    constructor(hexString: string);
-    constructor(idString: string);
-    constructor(array: number[]);
-    constructor(buffer: Buffer);
+declare const ObjectID: ObjectIDCtor;
 
-    readonly id: string;
-    readonly str: string;
+declare interface ObjectID {
+  readonly id: string;
+  readonly str: string;
 
-    toHexString(): string;
-    equals(other: ObjectID): boolean;
-    getTimestamp(): number;
+  toHexString(): string;
+  equals(other: ObjectID): boolean;
+  getTimestamp(): number;
+}
+
+declare interface ObjectIDCtor {
+  (): ObjectID
+  (time: number): ObjectID
+  (hexString: string): ObjectID
+  (idString: string): ObjectID
+  (array: number[]): ObjectID
+  (buffer: Buffer): ObjectID
+
+  new(): ObjectID
+  new(time: number): ObjectID
+  new(hexString: string): ObjectID
+  new(idString: string): ObjectID
+  new(array: number[]): ObjectID
+  new(buffer: Buffer): ObjectID
+
+
+  createFromTime(time: number): ObjectID;
+  createFromHexString(hexString: string): ObjectID;
+  isValid(hexString: string): boolean;
+  isValid(ObjectID: ObjectID): boolean;
+  generate(): string;
+  generate(time: number): string;
+  toString(): string;
 }

--- a/objectid.d.ts
+++ b/objectid.d.ts
@@ -33,7 +33,5 @@ declare interface ObjectIDCtor {
   createFromHexString(hexString: string): ObjectID;
   isValid(hexString: string): boolean;
   isValid(ObjectID: ObjectID): boolean;
-  generate(): string;
-  generate(time: number): string;
   toString(): string;
 }

--- a/typing-tests/objectid-tests.ts
+++ b/typing-tests/objectid-tests.ts
@@ -51,6 +51,38 @@ oid = ObjectID.createFromTime(time);
 oid = ObjectID.createFromHexString(hexString);
 
 // ----------------------------------------------------------------------------
+// should construct with no arguments
+oid = ObjectID();
+
+// ----------------------------------------------------------------------------
+// should have an `id` property
+oid.id;
+
+// ----------------------------------------------------------------------------
+// should have a `str` property
+oid.str;
+
+// ----------------------------------------------------------------------------
+// should construct with a `time` argument
+oid = ObjectID(time);
+
+// ----------------------------------------------------------------------------
+// should construct with an `array` argument
+oid = ObjectID(array);
+
+// ----------------------------------------------------------------------------
+// should construct with a `buffer` argument
+oid = ObjectID(buffer);
+
+// ----------------------------------------------------------------------------
+// should construct with a `hexString` argument
+oid = ObjectID(hexString);
+
+// ----------------------------------------------------------------------------
+// should construct with a `idString` argument
+oid = ObjectID(idString);
+
+// ----------------------------------------------------------------------------
 // should correctly retrieve timestamp
 const timestamp:number = oid.getTimestamp();
 


### PR DESCRIPTION
This updates the typescript definitions file to allow calling the `ObjectID` class without `new` - as documented in the [README](https://github.com/williamkapke/bson-objectid/blob/v2.0.1/README.md#usage) and [tests](https://github.com/williamkapke/bson-objectid/blob/v2.0.1/test/test.js#L94)

We use interfaces here to allow us to define an object as both "newable" and callable.

We have one interface for the class constructor, this defines how to call it (new & as a function) as well as the static methods. 

We then have another interface for the instance, this defines the members and methods.

We then have to export a `const ObjectID` so that typescript knows we are dealing with values, rather than types.