### PR TITLE
Update isValid method to match the bson node library

### DIFF
--- a/objectid.js
+++ b/objectid.js
@@ -133,7 +133,7 @@ ObjectID.isValid = function(id) {
   if (id == null) return false;
 
   try {
-    new ObjectId(id);
+    new ObjectID(id);
     return true;
   } catch {
     return false;

--- a/objectid.js
+++ b/objectid.js
@@ -132,31 +132,12 @@ ObjectID.createFromHexString = function(hexString) {
 ObjectID.isValid = function(id) {
   if (id == null) return false;
 
-  if (typeof id === 'number') {
+  try {
+    new ObjectId(id);
     return true;
+  } catch {
+    return false;
   }
-
-  if (typeof id === 'string') {
-    return id.length === 12 || (id.length === 24 && checkForHexRegExp.test(id));
-  }
-
-  if (id instanceof ObjectID) {
-    return true;
-  }
-
-  if (isBuffer(id)) {
-    return true;
-  }
-
-  // Duck-Typing detection of ObjectId like objects
-  if (
-      typeof id.toHexString === 'function' &&
-      (id.id instanceof _Buffer || typeof id.id === 'string')
-  ) {
-    return id.id.length === 12 || (id.id.length === 24 && checkForHexRegExp.test(id.id));
-  }
-
-  return false;
 };
 
 ObjectID.prototype = {


### PR DESCRIPTION
The bson node library recently updated the `ObjectID.isValid` method. 
This PR updates the method to match those changes. 

The bson library method can be seen here, at line 293: https://github.com/mongodb/js-bson/blob/master/src/objectid.ts