### PR TITLE
Revert "Update isValid method to match the bson node library"

### DIFF
--- a/objectid.js
+++ b/objectid.js
@@ -132,12 +132,31 @@ ObjectID.createFromHexString = function(hexString) {
 ObjectID.isValid = function(id) {
   if (id == null) return false;
 
-  try {
-    new ObjectID(id);
+  if (typeof id === 'number') {
     return true;
-  } catch {
-    return false;
   }
+
+  if (typeof id === 'string') {
+    return id.length === 12 || (id.length === 24 && checkForHexRegExp.test(id));
+  }
+
+  if (id instanceof ObjectID) {
+    return true;
+  }
+
+  if (isBuffer(id)) {
+    return true;
+  }
+
+  // Duck-Typing detection of ObjectId like objects
+  if (
+      typeof id.toHexString === 'function' &&
+      (id.id instanceof _Buffer || typeof id.id === 'string')
+  ) {
+    return id.id.length === 12 || (id.id.length === 24 && checkForHexRegExp.test(id.id));
+  }
+
+  return false;
 };
 
 ObjectID.prototype = {


### PR DESCRIPTION
Reverts williamkapke/bson-objectid#46

The PR #46 broke all tests.  I am going to revert it in the interim.

I also noticed we need to merge this https://github.com/418sec/bson-objectid/pull/2.